### PR TITLE
Removed database access in static_pages_controller

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,11 +6,9 @@ class StaticPagesController < ApplicationController
   end
 
   def about
-  	@campaign = Campaign.find(1)
   end
 
   def tour
-  	@campaign = Campaign.find(1)
   end
 
 end


### PR DESCRIPTION
It was looking in the database for your about and tour paths, though they are static elements, so should not need any database access.